### PR TITLE
feat(chat, cli, usage): enhance usage statistics and context window tracking

### DIFF
--- a/src/loco/usage.py
+++ b/src/loco/usage.py
@@ -5,58 +5,112 @@ from datetime import datetime
 from typing import Any
 
 
-# Approximate cost per 1M tokens (as of 2024)
-# Format: {model_prefix: (input_cost, output_cost)}
-MODEL_COSTS = {
+# Model information: costs and context windows
+# Format: {model_prefix: (input_cost, output_cost, context_window)}
+# Costs are per 1M tokens, context window is total tokens
+MODEL_INFO = {
     # OpenAI GPT-4
-    "gpt-4o": (2.50, 10.00),
-    "gpt-4o-mini": (0.15, 0.60),
-    "gpt-4-turbo": (10.00, 30.00),
-    "gpt-4": (30.00, 60.00),
-    "gpt-3.5-turbo": (0.50, 1.50),
-    
+    "gpt-4o": (2.50, 10.00, 128_000),
+    "gpt-4o-mini": (0.15, 0.60, 128_000),
+    "gpt-4-turbo": (10.00, 30.00, 128_000),
+    "gpt-4": (30.00, 60.00, 8_192),
+    "gpt-3.5-turbo": (0.50, 1.50, 16_385),
+
     # Anthropic Claude
-    "claude-3-5-sonnet": (3.00, 15.00),
-    "claude-3-opus": (15.00, 75.00),
-    "claude-3-sonnet": (3.00, 15.00),
-    "claude-3-haiku": (0.25, 1.25),
-    
+    "claude-3-5-sonnet": (3.00, 15.00, 200_000),
+    "claude-3-opus": (15.00, 75.00, 200_000),
+    "claude-3-sonnet": (3.00, 15.00, 200_000),
+    "claude-3-haiku": (0.25, 1.25, 200_000),
+
     # Other providers (approximate)
-    "gemini-1.5-pro": (1.25, 5.00),
-    "gemini-1.5-flash": (0.075, 0.30),
-    "command-r-plus": (3.00, 15.00),
-    "command-r": (0.50, 1.50),
+    "gemini-1.5-pro": (1.25, 5.00, 2_000_000),
+    "gemini-1.5-flash": (0.075, 0.30, 1_000_000),
+    "command-r-plus": (3.00, 15.00, 128_000),
+    "command-r": (0.50, 1.50, 128_000),
 }
+
+# Backward compatibility alias
+MODEL_COSTS = {k: v[:2] for k, v in MODEL_INFO.items()}
+
+
+def get_model_context_window(model: str) -> int | None:
+    """Get the context window size for a model.
+
+    Args:
+        model: The model identifier
+
+    Returns:
+        Context window size in tokens, or None if unknown
+    """
+    for model_prefix, info in MODEL_INFO.items():
+        if model_prefix in model.lower():
+            return info[2]  # Third element is context window
+
+    return None
 
 
 def estimate_cost(model: str, prompt_tokens: int, completion_tokens: int) -> float:
     """Estimate the cost of a completion based on token usage.
-    
+
     Args:
         model: The model identifier
         prompt_tokens: Number of input/prompt tokens
         completion_tokens: Number of output/completion tokens
-        
+
     Returns:
         Estimated cost in USD
     """
     # Find matching cost entry
     input_cost, output_cost = None, None
-    
+
     for model_prefix, costs in MODEL_COSTS.items():
         if model_prefix in model.lower():
             input_cost, output_cost = costs
             break
-    
+
     # If no match found, use a conservative estimate
     if input_cost is None:
         input_cost, output_cost = 5.00, 15.00
-    
+
     # Calculate cost (prices are per 1M tokens)
     total_cost = (prompt_tokens * input_cost / 1_000_000) + \
                  (completion_tokens * output_cost / 1_000_000)
-    
+
     return total_cost
+
+
+def estimate_conversation_tokens(conversation: Any) -> int:
+    """Estimate total tokens in a conversation.
+
+    This is a rough estimate based on message content length.
+    For more accurate counts, you'd need model-specific tokenizers.
+
+    Args:
+        conversation: A Conversation object with messages
+
+    Returns:
+        Estimated token count
+    """
+    total_chars = 0
+
+    for msg in conversation.messages:
+        if msg.content:
+            total_chars += len(msg.content)
+
+        # Tool calls add overhead
+        if msg.tool_calls:
+            import json
+            total_chars += len(json.dumps(msg.tool_calls))
+
+    # Rough estimate: ~4 characters per token (conservative for English)
+    # This varies by model and language
+    estimated_tokens = total_chars // 4
+
+    # Add overhead for message formatting, system prompts, etc.
+    # Typical overhead is ~10-20 tokens per message
+    message_overhead = len(conversation.messages) * 15
+
+    return estimated_tokens + message_overhead
 
 
 @dataclass
@@ -148,7 +202,26 @@ class SessionUsage:
     def get_call_count(self) -> int:
         """Get number of API calls made."""
         return len(self.stats)
-    
+
+    def get_context_percentage(self, model: str, estimated_conversation_tokens: int) -> float | None:
+        """Get percentage of context window used.
+
+        Args:
+            model: The model identifier
+            estimated_conversation_tokens: Estimated tokens in conversation
+
+        Returns:
+            Percentage (0-100) of context window used, or None if unknown
+        """
+        context_window = get_model_context_window(model)
+        if context_window is None:
+            return None
+
+        if context_window == 0:
+            return None
+
+        return (estimated_conversation_tokens / context_window) * 100
+
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for serialization."""
         return {


### PR DESCRIPTION
# Feat: Enhanced Context Tracking & Display

## Overview

Add comprehensive context tracking and display capabilities similar to Claude's interface, showing token usage and cost information both inline after each message and via command. This will help users understand their API consumption in real-time and make informed decisions about their usage.

## Current State

Loco already has excellent usage tracking infrastructure:
- ✅ `usage.py` - Token tracking and cost estimation
- ✅ `SessionUsage` class - Accumulates usage statistics
- ✅ `/stats` command - Shows cumulative session statistics
- ✅ Inline usage display - Shows tokens/cost after each turn

### Current Display Format
```
💭 1,234 tokens (in: 800, out: 434) • $0.0156
📊 Session: 5,678 tokens total • $0.0789 cumulative
```

## Problem Statement

While the current implementation is functional, it could be enhanced to provide:

1. **More granular context visibility** - Show context window usage percentage
2. **Better visual hierarchy** - Make usage info more prominent when needed
3. **Configurable display** - Let users control verbosity of usage information
4. **Budget tracking** - Warn users when approaching cost/token limits
5. **Model-specific context limits** - Display remaining context window space

## Proposed Solution

### 1. Enhanced Context Display

Add context window tracking alongside token counts:

```
💭 1,234 tokens (in: 800, out: 434) • $0.0156 • 12% context used
📊 Session: 5,678 tokens total • $0.0789 cumulative • 57% context used
```

For models nearing context limits, add visual warnings:

```
⚠️  4,567 tokens (in: 3,200, out: 1,367) • $0.0234 • 85% context used
📊 Session: 18,234 tokens total • $0.2345 cumulative • 85% context used
```

### 2. Model Context Limits Database

Extend `usage.py` with model context windows:

```python
# Format: {model_prefix: (input_cost, output_cost, context_window)}
MODEL_INFO = {
    "gpt-4o": (2.50, 10.00, 128_000),
    "gpt-4o-mini": (0.15, 0.60, 128_000),
    "gpt-4-turbo": (10.00, 30.00, 128_000),
    "gpt-4": (30.00, 60.00, 8_192),
    "claude-3-5-sonnet": (3.00, 15.00, 200_000),
    "claude-3-opus": (15.00, 75.00, 200_000),
    "claude-3-haiku": (0.25, 1.25, 200_000),
    # ... etc
}
```

### 3. New `/context` Command

Add a dedicated command for detailed context analysis:

```bash
/context
```

Output:
```
[bold]Context Usage[/bold]

  Model: openai/gpt-4o
  Context Window: 128,000 tokens
  
  Current Conversation:
    • System Prompt: 456 tokens
    • Messages: 4,123 tokens  
    • Tool Definitions: 289 tokens
    • Total Used: 4,868 tokens (3.8%)
    • Remaining: 123,132 tokens (96.2%)
  
  [dim]Note: Estimates based on message history. Actual tokenization may vary.[/dim]
```

### 4. Configuration Options

Add to `config.json`:

```json
{
  "usage_display": {
    "show_inline": true,              // Show after each message
    "show_context_percent": true,     // Show % of context window
    "show_session_cumulative": true,  // Show running totals
    "warn_threshold": 0.80,           // Warn at 80% context usage
    "budget_limit": null,             // Optional: max $ per session
    "token_limit": null               // Optional: max tokens per session
  }
}
```

### 5. Budget Warnings

When approaching configured limits:

```
⚠️  Budget Warning: $0.89 / $1.00 (89% of session limit)
⚠️  Token Warning: 9,234 / 10,000 tokens (92% of session limit)
```

### 6. Compact Display Mode

For users who prefer minimal output, support compact mode:

```
💭 1.2k tok • $0.02 • 12% ctx
```

Enable with:
```json
{
  "usage_display": {
    "compact": true
  }
}
```

## Implementation Plan

### Phase 1: Core Context Tracking (Week 1)
- [ ] Add `MODEL_INFO` with context window sizes
- [ ] Create `ContextTracker` class to estimate conversation token usage
- [ ] Add `get_context_percentage()` method to `SessionUsage`
- [ ] Update inline display to show context percentage

**Files to modify:**
- `src/loco/usage.py` - Add model info and context tracking
- `src/loco/chat.py` - Update `_display_usage_stats()`

### Phase 2: Enhanced Commands (Week 1-2)
- [ ] Implement `/context` command with detailed breakdown
- [ ] Add context warnings at 80% threshold
- [ ] Show visual indicators (colors) for context levels

**Files to modify:**
- `src/loco/cli.py` - Add `/context` command handler

### Phase 3: Configuration & Budgets (Week 2)
- [ ] Add `usage_display` config section
- [ ] Implement budget limit checking
- [ ] Add budget warnings
- [ ] Add compact display mode

**Files to modify:**
- `src/loco/config.py` - Add usage display config schema
- `src/loco/chat.py` - Check limits before API calls
- `src/loco/cli.py` - Display budget warnings

### Phase 4: Polish & Testing (Week 2-3)
- [ ] Add unit tests for context tracking
- [ ] Add tests for budget limits
- [ ] Update documentation
- [ ] Add examples to docs

**Files to create:**
- `tests/test_context_tracking.py`
- `docs/USAGE_TRACKING.md`

## Example Usage Flow

### Scenario 1: Normal Usage
```bash
$ loco

You> Help me refactor this function
💭 1,234 tokens (in: 800, out: 434) • $0.0156 • 1% context

Assistant> [response]

You> Can you add error handling?
💭 2,456 tokens (in: 1,600, out: 856) • $0.0312 • 2% context
📊 Session: 3,690 tokens total • $0.0468 cumulative • 3% context

You> /context

[bold]Context Usage[/bold]
  Model: openai/gpt-4o
  Context Window: 128,000 tokens
  Used: 3,690 tokens (2.9%)
  Remaining: 124,310 tokens (97.1%)
```

### Scenario 2: Approaching Limits
```bash
You> [large request with lots of context]

⚠️  12,456 tokens (in: 8,200, out: 4,256) • $0.1567 • 82% context
⚠️  Warning: Approaching context window limit (82% used)
📊 Session: 105,234 tokens total • $1.2345 cumulative • 82% context

You> /context

[bold]Context Usage[/bold]
  Model: claude-3-haiku
  Context Window: 200,000 tokens
  Used: 164,000 tokens (82.0%) ⚠️
  Remaining: 36,000 tokens (18.0%)
  
  [yellow]Warning: Consider /clear to reset context if conversation quality degrades.[/yellow]
```

### Scenario 3: Budget Limits
```bash
You> [request]

⚠️  Budget Warning: $0.95 / $1.00 (95% of session limit)

You> [another request]

[red]❌ Budget limit reached ($1.00). Session paused.[/red]
[dim]Use /clear to reset, or update budget in config.json[/dim]
```

## Technical Considerations

### Token Estimation
Since we don't have access to the exact tokenizer for all models:
1. Use `tiktoken` for OpenAI models (accurate)
2. Estimate ~1.3 tokens per word for others (approximate)
3. Add caveat in `/context` output about estimates

### Context Window Accuracy
Different model versions may have different context windows:
- Maintain a best-effort database
- Allow user overrides in config
- Default to conservative estimates if unknown

### Performance
- Context tracking should have minimal overhead
- Cache token counts for messages (don't recount)
- Only recalculate when messages change

## Alternative Approaches Considered

### 1. Real-time Tokenization
**Pros:** Most accurate
**Cons:** Requires model-specific tokenizers, adds latency
**Decision:** Use estimation with warnings about accuracy

### 2. Server-side Context Tracking
**Pros:** Could use actual model tokenization
**Cons:** Requires external service, privacy concerns
**Decision:** Keep everything local

### 3. Disable Usage Display by Default
**Pros:** Cleaner interface for users who don't care
**Cons:** Users might unknowingly rack up costs
**Decision:** Show by default, but make configurable

## Success Metrics

1. **Visibility** - Users can easily see context usage
2. **Control** - Users can configure display preferences  
3. **Awareness** - Budget warnings prevent surprise bills
4. **Accuracy** - Context estimates within 5% of actual (for known models)

## Documentation Updates

Add new documentation:
- `docs/USAGE_TRACKING.md` - Complete guide to usage tracking features
- Update `README.md` - Add usage tracking to features list
- Update `docs/CONFIGURATION.md` - Document usage_display options

## Migration Path

This is entirely additive:
- ✅ No breaking changes
- ✅ Existing `/stats` command continues to work
- ✅ Default behavior shows inline stats (already exists)
- ✅ New features are opt-in via config

## Future Enhancements

### Post-v1.0
1. **Usage Analytics**
   - Track usage over time
   - Cost/token graphs
   - Per-project budgets

2. **Smart Context Management**
   - Auto-summarize old messages when near limit
   - Suggest `/clear` at good breakpoints
   - Intelligent message pruning

3. **Team/Organization Features**
   - Shared budget pools
   - Usage reports
   - Cost allocation

4. **Integration with Cloud Dashboards**
   - Link to OpenAI/Anthropic usage dashboards
   - Pull actual costs vs estimates
   - Reconciliation reports

## Questions for Discussion

1. Should budget limits be hard stops or warnings?
2. What should the default warning threshold be? (80%? 90%?)
3. Should we include context percentage in the compact display?
4. Should we track context per-turn or per-session?
5. Do we need a `/budget` command separate from `/stats`?

## Conclusion

This proposal enhances loco's already-excellent usage tracking with:
- Better visibility into context window usage
- Configurable display options
- Budget protection features
- Detailed context analysis

The implementation is straightforward, building on existing infrastructure, with no breaking changes and a clear migration path.

---

**Author:** Loco Team  
**Date:** 2024-01-20  
**Status:** Draft  
**Related Issues:** N/A  
