### PR TITLE
fix: correct HTTP transport for GitHub MCP server

### DIFF
--- a/src/loco/mcp/transport.py
+++ b/src/loco/mcp/transport.py
@@ -48,7 +48,7 @@ class StdioTransport(MCPTransport):
             self._reader = asyncio.StreamReader()
             protocol = asyncio.StreamReaderProtocol(self._reader)
             await loop.connect_read_pipe(lambda: protocol, sys.stdin)
-            
+
             # For writing, we use stdout
             self._writer = None  # We'll write directly to stdout
 
@@ -56,7 +56,7 @@ class StdioTransport(MCPTransport):
         """Send a JSON-RPC message to stdout."""
         if self._closed:
             raise RuntimeError("Transport is closed")
-        
+
         # MCP uses JSON-RPC over stdio with newline delimiters
         json_str = json.dumps(message)
         sys.stdout.write(json_str + "\n")
@@ -65,16 +65,16 @@ class StdioTransport(MCPTransport):
     async def receive(self) -> AsyncIterator[dict[str, Any]]:
         """Receive JSON-RPC messages from stdin."""
         await self._setup()
-        
+
         if self._reader is None:
             raise RuntimeError("Reader not initialized")
-        
+
         while not self._closed:
             try:
                 line = await self._reader.readline()
                 if not line:
                     break
-                
+
                 line_str = line.decode('utf-8').strip()
                 if line_str:
                     yield json.loads(line_str)
@@ -103,7 +103,7 @@ class SSETransport(MCPTransport):
         """Send a message via POST."""
         if self._closed:
             raise RuntimeError("Transport is closed")
-        
+
         # In SSE, client sends via POST to a specific endpoint
         # This is a simplified implementation
         await self._send_queue.put(message)
@@ -115,7 +115,7 @@ class SSETransport(MCPTransport):
         while not self._closed:
             try:
                 message = await asyncio.wait_for(
-                    self._receive_queue.get(), 
+                    self._receive_queue.get(),
                     timeout=30.0
                 )
                 yield message
@@ -155,12 +155,12 @@ class ProcessTransport(MCPTransport):
         """Send a message to the process stdin."""
         if self._closed:
             raise RuntimeError("Transport is closed")
-        
+
         await self._ensure_process()
-        
+
         if self._process is None or self._process.stdin is None:
             raise RuntimeError("Process stdin not available")
-        
+
         json_str = json.dumps(message) + "\n"
         self._process.stdin.write(json_str.encode('utf-8'))
         await self._process.stdin.drain()
@@ -168,16 +168,16 @@ class ProcessTransport(MCPTransport):
     async def receive(self) -> AsyncIterator[dict[str, Any]]:
         """Receive messages from the process stdout."""
         await self._ensure_process()
-        
+
         if self._process is None or self._process.stdout is None:
             raise RuntimeError("Process stdout not available")
-        
+
         while not self._closed:
             try:
                 line = await self._process.stdout.readline()
                 if not line:
                     break
-                
+
                 line_str = line.decode('utf-8').strip()
                 if line_str:
                     yield json.loads(line_str)
@@ -189,12 +189,12 @@ class ProcessTransport(MCPTransport):
     async def close(self) -> None:
         """Close the transport and terminate the process."""
         self._closed = True
-        
+
         if self._process:
             if self._process.stdin:
                 self._process.stdin.close()
                 await self._process.stdin.wait_closed()
-            
+
             try:
                 await asyncio.wait_for(self._process.wait(), timeout=5.0)
             except asyncio.TimeoutError:
@@ -207,7 +207,11 @@ class ProcessTransport(MCPTransport):
 
 
 class HTTPTransport(MCPTransport):
-    """HTTP transport for MCP (for HTTP-based MCP servers)."""
+    """HTTP transport for MCP (for HTTP-based MCP servers).
+    
+    This transport uses a request/response pattern where each message sent
+    via POST receives an SSE (Server-Sent Events) response on the same connection.
+    """
 
     def __init__(self, url: str, headers: dict[str, str] | None = None):
         if not HAS_AIOHTTP:
@@ -215,13 +219,12 @@ class HTTPTransport(MCPTransport):
                 "aiohttp is required for HTTP transport. "
                 "Install it with: pip install aiohttp"
             )
-        
+
         self.url = url
         self.headers = headers or {}
         self._session: aiohttp.ClientSession | None = None
         self._closed = False
         self._receive_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
-        self._sse_task: asyncio.Task | None = None
 
     async def _ensure_session(self) -> aiohttp.ClientSession:
         """Ensure the aiohttp session is created."""
@@ -229,60 +232,61 @@ class HTTPTransport(MCPTransport):
             self._session = aiohttp.ClientSession(headers=self.headers)
         return self._session
 
-    async def _sse_reader(self) -> None:
-        """Read Server-Sent Events from the endpoint."""
-        session = await self._ensure_session()
-        
-        try:
-            async with session.get(self.url) as response:
-                async for line in response.content:
-                    if self._closed:
-                        break
-                    
-                    line_str = line.decode('utf-8').strip()
-                    
-                    # SSE format: "data: <json>"
-                    if line_str.startswith('data: '):
-                        data_str = line_str[6:]  # Remove "data: " prefix
-                        if data_str:
-                            try:
-                                message = json.loads(data_str)
-                                await self._receive_queue.put(message)
-                            except json.JSONDecodeError:
-                                sys.stderr.write(f"Failed to decode SSE message: {data_str}\n")
-                                sys.stderr.flush()
-        except Exception as e:
-            if not self._closed:
-                sys.stderr.write(f"SSE reader error: {e}\n")
-                sys.stderr.flush()
-
     async def send(self, message: dict[str, Any]) -> None:
-        """Send a message via POST."""
+        """Send a message via POST and read the SSE response.
+        
+        The GitHub MCP server responds with Server-Sent Events on the same
+        POST connection that we use to send the request.
+        """
         if self._closed:
             raise RuntimeError("Transport is closed")
 
         session = await self._ensure_session()
-        
+
         try:
             async with session.post(
                 self.url,
                 json=message,
                 headers={"Content-Type": "application/json"},
             ) as response:
-                if response.status != 200:
+                # 200 = successful request with response
+                # 202 = successful notification (no response expected)
+                if response.status not in (200, 202):
                     error_text = await response.text()
                     raise RuntimeError(
                         f"HTTP error {response.status}: {error_text}"
                     )
+                
+                # For notifications (202), there's no response to read
+                if response.status == 202:
+                    return
+                
+                # Read SSE response from the POST connection
+                async for line in response.content:
+                    if self._closed:
+                        break
+
+                    line_str = line.decode('utf-8').strip()
+
+                    # SSE format: "data: <json>"
+                    if line_str.startswith('data: '):
+                        data_str = line_str[6:]  # Remove "data: " prefix
+                        if data_str:
+                            try:
+                                response_message = json.loads(data_str)
+                                await self._receive_queue.put(response_message)
+                                # For request/response pattern, we only expect one response per request
+                                break
+                            except json.JSONDecodeError:
+                                sys.stderr.write(f"Failed to decode SSE message: {data_str}\n")
+                                sys.stderr.flush()
+                    # Ignore "event:" lines and empty lines
+                    
         except aiohttp.ClientError as e:
             raise RuntimeError(f"Failed to send message: {e}")
 
     async def receive(self) -> AsyncIterator[dict[str, Any]]:
-        """Receive messages from the queue (populated by SSE reader)."""
-        # Start SSE reader if not already running
-        if self._sse_task is None:
-            self._sse_task = asyncio.create_task(self._sse_reader())
-        
+        """Receive messages from the queue (populated by send() method)."""
         while not self._closed:
             try:
                 message = await asyncio.wait_for(
@@ -298,13 +302,6 @@ class HTTPTransport(MCPTransport):
     async def close(self) -> None:
         """Close the transport and cleanup resources."""
         self._closed = True
-        
-        if self._sse_task:
-            self._sse_task.cancel()
-            try:
-                await self._sse_task
-            except asyncio.CancelledError:
-                pass
-        
+
         if self._session:
             await self._session.close()


### PR DESCRIPTION
## Problem
The GitHub MCP server was timing out during initialization with errors like:
```
✗ github: Timeout after 10s
Unclosed client session
Unclosed connector
```

The `loco mcp test github` and `loco mcp tools github` commands would fail consistently, preventing any GitHub MCP integration from working.

## Root Cause
The `HTTPTransport` class in `src/loco/mcp/transport.py` had a fundamentally incorrect implementation for HTTP-based MCP servers that use Server-Sent Events (SSE):

### Old (Broken) Behavior
- `send()` method would POST a message and immediately close the connection
- `_sse_reader()` method would attempt to open a separate GET request to read SSE responses
- This didn't match how the GitHub MCP server actually works

### Actual GitHub MCP Server Protocol
- Client sends a **POST request** with JSON-RPC message
- Server responds with **SSE format on the SAME POST connection** (not a separate connection)
- Each request/response is a separate POST+SSE pair
- Notifications (messages without `id` field) return **HTTP 202 Accepted**
- Regular requests return **HTTP 200 OK**

## Solution
Completely rewrote the `HTTPTransport` class to implement the correct protocol:

### Key Changes
1. **Removed `_sse_reader()` method** - No longer needed since responses come on the same POST connection
2. **Fixed `send()` method** to:
   - POST the message
   - **Read the SSE response from the same connection** (don't close it immediately)
   - Parse SSE lines and extract JSON from `data:` prefixed lines
   - Queue the response for the `receive()` method
3. **Handle HTTP status codes properly**:
   - HTTP 200: Request with response - read and queue the response
   - HTTP 202: Notification - no response expected, just return
4. **Simplified `receive()` method** - now just yields from the queue populated by `send()`
5. **Updated class docstring** to document the correct request/response pattern

## Verification
Tested the fix with:
- ✅ `loco mcp test github` → `✓ github: OK - 40 tool(s) available`
- ✅ `loco mcp tools github` → Successfully lists all 40 GitHub MCP tools
- ✅ Manual async test confirms initialization, tool listing, and cleanup work correctly

## Files Changed
- `src/loco/mcp/transport.py` - Fixed HTTPTransport class (58 insertions, 61 deletions)

## Impact
This fix enables the GitHub MCP server to work properly with loco, allowing users to leverage GitHub's powerful set of tools for repository management, issue tracking, pull requests, code search, and more.